### PR TITLE
[Refacotring] Employee constructor에서 struct를 인자로 받도록 수정

### DIFF
--- a/Developers/command.h
+++ b/Developers/command.h
@@ -24,7 +24,14 @@ public:
 
 	virtual string run(){
 		AddCmdParser addCmdParser(commandStr_);
-		Employee employee(addCmdParser.getEmployeeNum(), addCmdParser.getName(), addCmdParser.getCl(), addCmdParser.getPhoneNum(), addCmdParser.getBirthday(), addCmdParser.getCerti());
+		struct EmployeeInfo employeeInfo;
+		employeeInfo.employeeNum = addCmdParser.getEmployeeNum();
+		employeeInfo.name = addCmdParser.getName();
+		employeeInfo.cl = addCmdParser.getCl();
+		employeeInfo.phoneNum = addCmdParser.getPhoneNum();
+		employeeInfo.birthday = addCmdParser.getBirthday();
+		employeeInfo.certi = addCmdParser.getCerti();
+		Employee employee(employeeInfo);
 		db_->add(&employee);
 		// delete employee;
 		return "";

--- a/Developers/database.cpp
+++ b/Developers/database.cpp
@@ -5,8 +5,14 @@
 using namespace std;
 
 void DataBase::add(Employee* employee) {
-	Employee* empl = new Employee(employee->getEmployeeNum(), employee->getName(), 
-		employee->getCl(), employee->getPhoneNum(), employee->getBirthday(), employee->getCerti());
+	struct EmployeeInfo employeeInfo;
+	employeeInfo.employeeNum = employee->getEmployeeNum();
+	employeeInfo.name = employee->getName();
+	employeeInfo.cl = employee->getCl();
+	employeeInfo.phoneNum = employee->getPhoneNum();
+	employeeInfo.birthday = employee->getBirthday();
+	employeeInfo.certi = employee->getCerti();
+	Employee* empl = new Employee(employeeInfo);
 	if (empl == nullptr) {
 		cout << "Error : Failed to alloc!" << endl;
 		return;

--- a/Developers/database.cpp
+++ b/Developers/database.cpp
@@ -5,14 +5,7 @@
 using namespace std;
 
 void DataBase::add(Employee* employee) {
-	struct EmployeeInfo employeeInfo;
-	employeeInfo.employeeNum = employee->getEmployeeNum();
-	employeeInfo.name = employee->getName();
-	employeeInfo.cl = employee->getCl();
-	employeeInfo.phoneNum = employee->getPhoneNum();
-	employeeInfo.birthday = employee->getBirthday();
-	employeeInfo.certi = employee->getCerti();
-	Employee* empl = new Employee(employeeInfo);
+	Employee* empl = new Employee(*employee);
 	if (empl == nullptr) {
 		cout << "Error : Failed to alloc!" << endl;
 		return;

--- a/Developers/employee.cpp
+++ b/Developers/employee.cpp
@@ -1,7 +1,7 @@
 #include "employee.h"
 
-Employee::Employee(const string employeeNum, const string name, const string cl, const string phoneNum, const string birthday, const string certi) :
-    employeeNum_(employeeNum), name_(name), cl_(cl), phoneNum_(phoneNum), birthday_(birthday), certi_(certi) {
+Employee::Employee(const EmployeeInfo employeeInfo) :
+	employeeNum_(employeeInfo.employeeNum), name_(employeeInfo.name), cl_(employeeInfo.cl), phoneNum_(employeeInfo.phoneNum), birthday_(employeeInfo.birthday), certi_(employeeInfo.certi) {
 }
 
 string Employee::getEmployeeNum() const {

--- a/Developers/employee.h
+++ b/Developers/employee.h
@@ -5,6 +5,15 @@
 
 using namespace std;
 
+struct EmployeeInfo {
+	string employeeNum;
+	string name;
+	string cl;
+	string phoneNum;
+	string birthday;
+	string certi;
+};
+
 class EmployeeNum {
 public:
 	EmployeeNum(const string employeeNum) {
@@ -116,7 +125,7 @@ private:
 
 class Employee {
 public:
-	Employee(const string employeeNum, const string name, const string cl, const string phoneNum, const string birthday, const string certi);
+	Employee(const EmployeeInfo employeeInfo);
 	string getEmployeeNum() const;
 	string getName() const;
 	string getCl() const;

--- a/Test/test_add.cpp
+++ b/Test/test_add.cpp
@@ -7,9 +7,9 @@ TEST(FunctionTest1, TestAdd) {
 
 	vector<Employee*> result;
 
-	db->add(new Employee("14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV"));
-	db->add(new Employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV"));
-	db->add(new Employee("17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO"));
+	db->add(new Employee({ "14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV" }));
+	db->add(new Employee({ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" }));
+	db->add(new Employee({ "17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO" }));
 
 	result = db->sch(' ', "employeeNum", "14130827");
 	EXPECT_EQ("14130827", result[0]->getEmployeeNum());

--- a/Test/test_del.cpp
+++ b/Test/test_del.cpp
@@ -7,12 +7,12 @@ TEST(FunctionTest1, TestDel) {
 	vector<Employee*> delList;
 	vector<Employee*> result;
 
-	db->add(new Employee("14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV"));
-	db->add(new Employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV"));
-	db->add(new Employee("17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO"));
+	db->add(new Employee({ "14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV" }));
+	db->add(new Employee({ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" }));
+	db->add(new Employee({ "17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO" }));
 
-	delList.push_back(new Employee("14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV"));
-	delList.push_back(new Employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV"));
+	delList.push_back(new Employee({ "14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV" }));
+	delList.push_back(new Employee({ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" }));
 
 	db->del(delList);
 

--- a/Test/test_employee.cpp
+++ b/Test/test_employee.cpp
@@ -2,7 +2,7 @@
 #include "test_header.h"
 
 TEST(EmployeeTest, GetTest) {
-	Employee employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
+	Employee employee(EmployeeInfo{ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
 
 	EXPECT_EQ("15123099", employee.getEmployeeNum());
 	EXPECT_EQ("VXIHXOTH JHOP", employee.getName());
@@ -21,7 +21,7 @@ TEST(EmployeeTest, GetTest) {
 }
 
 TEST(EmployeeTest, SetTest) {
-	Employee employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
+	Employee employee(EmployeeInfo{ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
 
 	employee.setName("FB NTAWR");
 	EXPECT_EQ("FB NTAWR", employee.getName());
@@ -40,27 +40,27 @@ TEST(EmployeeTest, SetTest) {
 }
 
 TEST(EmployeeTest, EmployeeNumTest) {
-	Employee employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
+	Employee employee(EmployeeInfo{ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
 	EXPECT_EQ("15123099", employee.getEmployeeNum());
 
-	Employee employee2("69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
+	Employee employee2(EmployeeInfo{ "69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
 	EXPECT_EQ("69123099", employee2.getEmployeeNum());
 }
 
 TEST(EmployeeTest, EmployeeCompareOperatorTest) {
-	Employee employee1("69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
-	Employee employee2("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
-	Employee employee3("20123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
+	Employee employee1({ "69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
+	Employee employee2({ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
+	Employee employee3({ "20123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
 	EXPECT_TRUE(employee1 < employee2);
 	EXPECT_TRUE(employee2 < employee3);
 	EXPECT_TRUE(employee1 < employee3);
 }
 
 TEST(EmployeeTest, EmployeeEqualOperatorTest) {
-	Employee employee1("69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
-	Employee employee2("69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
-	Employee employee3("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
-	Employee employee4("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV");
+	Employee employee1( {"69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
+	Employee employee2( {"69123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
+	Employee employee3( {"15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
+	Employee employee4( {"15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" });
 	EXPECT_TRUE(employee1 == employee2);
 	EXPECT_TRUE(employee3 == employee4);
 }

--- a/Test/test_mod.cpp
+++ b/Test/test_mod.cpp
@@ -7,11 +7,11 @@ TEST(FunctionTest1, TestMod) {
 	vector<Employee*> modList;
 	vector<Employee*> result;
 
-	db->add(new Employee("14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV"));
-	db->add(new Employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV"));
-	db->add(new Employee("17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO"));
+	db->add(new Employee({ "14130827", "RPO JK", "CL4", "010-3231-1698", "20090201", "ADV" }));
+	db->add(new Employee({ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" }));
+	db->add(new Employee({ "17112609", "FB NTAWR", "CL4", "010-5645-6122", "19861203", "PRO" }));
 
-	modList.push_back(new Employee("15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV"));
+	modList.push_back(new Employee({ "15123099", "VXIHXOTH JHOP", "CL3", "010-3112-2609", "19771211", "ADV" }));
 
 	db->mod(modList, "name", "JOOHWAN KIM");
 

--- a/Test/test_sch.cpp
+++ b/Test/test_sch.cpp
@@ -5,9 +5,9 @@
 
 TEST(DatabaseTest, SchTest) {
 	DataBase* testList = new DataBase();
-	// DB Ãß°¡ ÇÊ¿ä
+	// DB ï¿½ß°ï¿½ ï¿½Ê¿ï¿½
 	vector<Employee*> cmpList;
-	Employee* employee = new Employee("15123099", "LEE JY", "CL3", "010-1234-5678", "19001122", "PRO");
+	Employee* employee = new Employee({ "15123099", "LEE JY", "CL3", "010-1234-5678", "19001122", "PRO" });
 
 	cmpList.push_back(employee);
 	testList->add(employee);


### PR DESCRIPTION
기존 Employee constructor의 인자 개수가 많아서 struct를 인자로 받도록 수정